### PR TITLE
Add shared hhd.css file

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -6,6 +6,9 @@
   "version": "v0.2.0",
   "target": "System-Wide",
   "manifest_version": 9,
+  "inject": {
+    "themes/hhd.css": ["QuickAccess"]
+  },
   "patches": {
     "Handheld": {
       "type": "dropdown",

--- a/themes/hhd.css
+++ b/themes/hhd.css
@@ -1,0 +1,5 @@
+/* Hide QAM Option HHD Handles */
+._2C0g0iG5dUfQ1LijT3sbjn > div:nth-child(14) {
+    display: none;
+    visibility: hidden;
+}


### PR DESCRIPTION
Hides the GPU Frequency slider in the QAM. This is now handled by the HHD overlay and the slider in Steam does nothing.